### PR TITLE
At Cisco ISR 4331 ';tclquit' command in the end of string does not do…

### DIFF
--- a/chAngel.py
+++ b/chAngel.py
@@ -56,7 +56,7 @@ def main():
 				tclOut.append('if { [regexp "%s " [exec show ip interface brief] ] } { ios_config "interface %s" "no delay" "end" }' % (i.name, i.name) )
 			else:
 				tclOut.append('if { [regexp "%s " [exec show ip interface brief] ] } { ios_config "interface %s" "delay 1000000" "end" }' % (i.name, i.name) )
-		pyperclip.copy('tclsh\n\n' + ';'.join(tclOut) + ' ; tclquit\n')
+		pyperclip.copy('tclsh\n\n' + ';'.join(tclOut) + '\ntclquit\n')
 
 	else:
 		print('---------Paste to CLI exec mode------------')


### PR DESCRIPTION
… exit from tclsh mode.

Move 'tclquit' to the next string